### PR TITLE
Optimize delete range

### DIFF
--- a/node/scan.go
+++ b/node/scan.go
@@ -105,6 +105,7 @@ func (nd *KVNode) scanCommand(cmd redcon.Command) (interface{}, error) {
 // here cursor is the scan key for start, (table:key)
 // and the response will return the next start key for next scan,
 // (note: it is not the "0" as the redis scan to indicate the end of scan)
+// advscan will stop if crossing table
 func (nd *KVNode) advanceScanCommand(cmd redcon.Command) (interface{}, error) {
 	if len(cmd.Args) < 3 {
 		return &common.ScanResult{Keys: nil, NextCursor: nil, PartionId: "", Error: common.ErrInvalidArgs}, common.ErrInvalidArgs

--- a/rockredis/const.go
+++ b/rockredis/const.go
@@ -79,7 +79,7 @@ var (
 const (
 	defaultScanCount int = 100
 	MAX_BATCH_NUM        = 5000
-	RANGE_DELETE_NUM     = 100000
+	RangeDeleteNum       = 100
 )
 
 var (

--- a/rockredis/fullscan.go
+++ b/rockredis/fullscan.go
@@ -287,6 +287,7 @@ func (db *RockDB) buildFullScanIterator(storeDataType byte, table,
 		return nil, err
 	}
 
+	dbLog.Debugf("full scan range: %v, %v, %v, %v", minKey, maxKey, string(minKey), string(maxKey))
 	//	minKey = minKey[:0]
 	it, err := NewDBRangeLimitIterator(db.eng, minKey, maxKey, common.RangeOpen, 0, count+1, false)
 	if err != nil {

--- a/rockredis/rockredis.go
+++ b/rockredis/rockredis.go
@@ -564,7 +564,16 @@ func (r *RockDB) DeleteTableRange(dt string, table string, start []byte, end []b
 	return nil
 }
 
+func (r *RockDB) GetTablesSizes(tables []string) []int64 {
+	// try all data types for each table
+	return nil
+}
+
 func (r *RockDB) GetTableSizeInRange(dt string, table string, start []byte, end []byte) int64 {
+	//rg := getTableRange(dt, table, start, end)
+	//rgs := make([]gorocksdb.Range, 0, 1)
+	//rgs = append(rgs, rg)
+	//s := r.eng.GetApproximateSizes(rgs)
 	return 0
 }
 

--- a/rockredis/scan.go
+++ b/rockredis/scan.go
@@ -155,6 +155,7 @@ func checkScanCount(count int) int {
 	return count
 }
 
+// note: this scan will not stop while cross table, it will scan begin from key until count or no more in db.
 func (db *RockDB) scanGenericUseBuffer(storeDataType byte, key []byte, count int,
 	match string, inputBuffer [][]byte) ([][]byte, error) {
 	r, err := buildMatchRegexp(match)
@@ -166,6 +167,7 @@ func (db *RockDB) scanGenericUseBuffer(storeDataType byte, key []byte, count int
 	if err != nil {
 		return nil, err
 	}
+	dbLog.Debugf("scan range: %v, %v", minKey, maxKey)
 	count = checkScanCount(count)
 
 	it, err := db.buildScanIterator(minKey, maxKey)


### PR DESCRIPTION
For some small range, we avoid the delete range in rocksdb. (Seems too much small delete ranges impact the rocksdb performance)